### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2.2.0
+
+### Features
+- Added option to hide default Blizzard cast bar (under Player Castbar settings)
+
+## v2.1.0
+
+### Fixes
+- Adjusted default positions for target-of-target and focus castbars to avoid overlap with action bars
+- Fixed release zip containing lowercase folder name causing addon to fail to load
+
 ## v2.0.0
 
 ### Features

--- a/Castborn.toc
+++ b/Castborn.toc
@@ -2,7 +2,7 @@
 ## Title: Castborn
 ## Notes: Castbar addon with DoT tracking, swing timers, and more
 ## Author: Lightborn
-## Version: 2.1.0
+## Version: 2.2.0
 ## SavedVariables: CastbornDB
 ## OptionalDeps: Masque
 ## IconTexture: Interface\Icons\Spell_Arcane_Arcane04

--- a/Core.lua
+++ b/Core.lua
@@ -8,7 +8,7 @@ local CB = Castborn
 
 -- Addon info
 CB.name = "Castborn"
-CB.version = "2.1.0"
+CB.version = "2.2.0"
 
 -- Module registry and event bus
 CB.modules = {}
@@ -133,6 +133,7 @@ CB.defaults = {
         showTime = true,
         showSpellName = true,
         showLatency = true,
+        hideBlizzardCastBar = true,
         barColor = {0.4, 0.6, 0.9, 1},
         channelColor = {0.3, 0.8, 0.3, 1},
         bgColor = {0.1, 0.1, 0.1, 0.8},

--- a/Modules/CastBars.lua
+++ b/Modules/CastBars.lua
@@ -358,9 +358,9 @@ function CB:InitCastBars()
     CB.castbars.targettarget = CreateCastBar("targettarget", "targettarget")
     CB.castbars.focus = CreateCastBar("focus", "focus")
 
-    -- Hide the default Blizzard castbar when player castbar is enabled
-    if CB.db.player and CB.db.player.enabled then
-        CB:HideBlizzardCastBar()
+    -- Hide the default Blizzard castbar if setting is enabled
+    if CB.db.player and CB.db.player.hideBlizzardCastBar then
+        CB:HideBlizzardCastBar(true)  -- silent on init
     end
 
     -- Fire callback so GCD and 5SR modules can anchor to the player castbar
@@ -455,7 +455,7 @@ function CB:InitCastBars()
 end
 
 -- Hide the default Blizzard castbar
-function CB:HideBlizzardCastBar()
+function CB:HideBlizzardCastBar(silent)
     -- Try different names used across WoW versions
     local blizzardCastBars = {
         "CastingBarFrame",           -- Classic/TBC
@@ -472,7 +472,9 @@ function CB:HideBlizzardCastBar()
         end
     end
 
-    CB:Print("Default Blizzard castbar disabled")
+    if not silent then
+        CB:Print("Default Blizzard castbar hidden")
+    end
 end
 
 -- Restore the default Blizzard castbar (if needed)
@@ -482,7 +484,7 @@ function CB:ShowBlizzardCastBar()
         frame:SetScript("OnShow", nil)
         -- Re-register events would require knowing original events
         -- For now, just recommend /reload to restore
-        CB:Print("Reload UI to fully restore Blizzard castbar")
+        CB:Print("Reload UI to fully restore Blizzard castbar (/reload)")
     end
 end
 

--- a/Systems/Options.lua
+++ b/Systems/Options.lua
@@ -470,6 +470,16 @@ function Options:BuildCastbars(parent)
     cb4:SetPoint("TOPLEFT", 0, y)
     local cb5 = CreateCheckbox(parent, "Show Latency", CastbornDB.player, "showLatency")
     cb5:SetPoint("TOPLEFT", 150, y)
+    y = y - 26
+
+    local cb6 = CreateCheckbox(parent, "Hide Blizzard Castbar", CastbornDB.player, "hideBlizzardCastBar", function(checked)
+        if checked then
+            Castborn:HideBlizzardCastBar()
+        else
+            Castborn:ShowBlizzardCastBar()
+        end
+    end)
+    cb6:SetPoint("TOPLEFT", 0, y)
     y = y - 36
 
     local slider1 = CreateSlider(parent, "Width", CastbornDB.player, "width", 100, 400, 10, function(v)
@@ -869,7 +879,7 @@ local function CreateInterfacePanel()
 
     local version = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
     version:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -4)
-    version:SetText("Version 2.1.0")
+    version:SetText("Version 2.2.0")
 
     local desc = panel:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     desc:SetPoint("TOPLEFT", version, "BOTTOMLEFT", 0, -12)


### PR DESCRIPTION
- Add option to hide default Blizzard cast bar (under Player Castbar settings)
- Bump version to 2.2.0
- Update changelog