### PR TITLE
Fix CurseForge version display

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
           rm -rf Castborn castborn
           mkdir Castborn
           cp -r Core.lua Systems/ Modules/ Data/ Castborn.toc CHANGELOG.md Castborn/
+          # Replace version placeholder with tag
+          sed -i "s/@project-version@/${{ github.ref_name }}/g" Castborn/Castborn.toc
           # Use -r to recurse and preserve folder name exactly
           zip -r "Castborn-${{ github.ref_name }}.zip" Castborn/
 

--- a/Castborn.toc
+++ b/Castborn.toc
@@ -2,7 +2,7 @@
 ## Title: Castborn
 ## Notes: Castbar addon with DoT tracking, swing timers, and more
 ## Author: Lightborn
-## Version: 2.3.0
+## Version: @project-version@
 ## SavedVariables: CastbornDB
 ## OptionalDeps: Masque
 ## IconTexture: Interface\Icons\Spell_Arcane_Arcane04


### PR DESCRIPTION
Use @project-version@ placeholder in TOC for CurseForge packager to correctly read version from git tag.