### PR TITLE
feat(cooldowns): add defaults for Mage, Priest, Warlock, Paladin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.5.0
+
+### Features
+- Added default cooldown tracking for Mage, Priest, Warlock, and Paladin
+- Cooldown tracker now automatically shows class-relevant abilities (Cold Snap, Icy Veins, etc.)
+
 ## v2.4.2
 
 ### Changes

--- a/Core.lua
+++ b/Core.lua
@@ -8,7 +8,7 @@ local CB = Castborn
 
 -- Addon info
 CB.name = "Castborn"
-CB.version = "2.4.2"
+CB.version = "2.5.0"
 
 -- Module registry and event bus
 CB.modules = {}

--- a/Data/SpellData.lua
+++ b/Data/SpellData.lua
@@ -195,6 +195,43 @@ SpellData.dots = {
     [25457] = { name = "Flame Shock", school = 4, duration = 12 },    -- TBC
 }
 
+-- Class cooldowns to track by default
+SpellData.cooldowns = {
+    MAGE = {
+        { spellId = 11958, name = "Cold Snap" },
+        { spellId = 12472, name = "Icy Veins" },
+        { spellId = 12042, name = "Arcane Power" },
+        { spellId = 12043, name = "Presence of Mind" },
+        { spellId = 11129, name = "Combustion" },
+        { spellId = 12051, name = "Evocation" },
+    },
+    WARLOCK = {
+        { spellId = 18708, name = "Fel Domination" },
+        { spellId = 17962, name = "Conflagrate" },
+        { spellId = 18288, name = "Amplify Curse" },
+        { spellId = 17877, name = "Shadowburn" },
+        { spellId = 18223, name = "Curse of Exhaustion" },
+    },
+    PRIEST = {
+        { spellId = 14751, name = "Inner Focus" },
+        { spellId = 10060, name = "Power Infusion" },
+        { spellId = 15487, name = "Silence" },
+        { spellId = 34433, name = "Shadowfiend" },
+        { spellId = 32379, name = "Shadow Word: Death" },
+    },
+    PALADIN = {
+        { spellId = 31842, name = "Divine Illumination" },
+        { spellId = 20216, name = "Divine Favor" },
+        { spellId = 31884, name = "Avenging Wrath" },
+        { spellId = 642, name = "Divine Shield" },
+        { spellId = 1044, name = "Blessing of Freedom" },
+    },
+}
+
+function SpellData:GetClassCooldowns(class)
+    return self.cooldowns[class] or {}
+end
+
 function SpellData:GetSchoolColor(school)
     return self.schoolColors[school] or { 0.7, 0.7, 0.7, 1 }
 end

--- a/Modules/CooldownTracker.lua
+++ b/Modules/CooldownTracker.lua
@@ -214,6 +214,15 @@ Castborn:RegisterCallback("INIT", function()
 end)
 
 Castborn:RegisterCallback("READY", function()
+    -- Load class defaults if no spells are tracked
+    local db = CastbornDB.cooldowns
+    if not db.trackedSpells or #db.trackedSpells == 0 then
+        local _, class = UnitClass("player")
+        if class and Castborn.SpellData then
+            db.trackedSpells = Castborn.SpellData:GetClassCooldowns(class)
+        end
+    end
+
     CreateContainer()
     UpdateLayout()
 


### PR DESCRIPTION
## Summary
- Added default cooldown spells for Mage, Priest, Warlock, and Paladin
- Cooldown tracker now auto-loads class defaults when no custom spells configured

## Classes & Cooldowns
- **Mage**: Cold Snap, Icy Veins, Arcane Power, Presence of Mind, Combustion, Evocation
- **Warlock**: Fel Domination, Conflagrate, Amplify Curse, Shadowburn, Curse of Exhaustion
- **Priest**: Inner Focus, Power Infusion, Silence, Shadowfiend, Shadow Word: Death
- **Paladin**: Divine Illumination, Divine Favor, Avenging Wrath, Divine Shield, Blessing of Freedom