### PR TITLE
fix(cooldowns): add Ice Block and fix upgrade migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.5.1
+
+### Fixes
+- Added Ice Block to Mage default cooldowns
+- Fixed upgrade migration so existing users get new default cooldowns
+
 ## v2.5.0
 
 ### Features

--- a/Core.lua
+++ b/Core.lua
@@ -8,7 +8,7 @@ local CB = Castborn
 
 -- Addon info
 CB.name = "Castborn"
-CB.version = "2.5.0"
+CB.version = "2.5.1"
 
 -- Module registry and event bus
 CB.modules = {}

--- a/Data/SpellData.lua
+++ b/Data/SpellData.lua
@@ -198,6 +198,7 @@ SpellData.dots = {
 -- Class cooldowns to track by default
 SpellData.cooldowns = {
     MAGE = {
+        { spellId = 45438, name = "Ice Block" },
         { spellId = 11958, name = "Cold Snap" },
         { spellId = 12472, name = "Icy Veins" },
         { spellId = 12042, name = "Arcane Power" },

--- a/Modules/CooldownTracker.lua
+++ b/Modules/CooldownTracker.lua
@@ -214,12 +214,13 @@ Castborn:RegisterCallback("INIT", function()
 end)
 
 Castborn:RegisterCallback("READY", function()
-    -- Load class defaults if no spells are tracked
+    -- Load class defaults if no spells tracked or upgrading from pre-2.5.0
     local db = CastbornDB.cooldowns
-    if not db.trackedSpells or #db.trackedSpells == 0 then
+    if not db.trackedSpells or #db.trackedSpells == 0 or not db.defaultsLoaded then
         local _, class = UnitClass("player")
         if class and Castborn.SpellData then
             db.trackedSpells = Castborn.SpellData:GetClassCooldowns(class)
+            db.defaultsLoaded = "2.5.0"
         end
     end
 


### PR DESCRIPTION
## Summary
- Added Ice Block to Mage default cooldowns
- Fixed upgrade migration so existing users get new default cooldowns automatically