### PR TITLE
feat(cooldowns): add Ice Barrier to Mage defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.6.1
+
+### Features
+- Added Ice Barrier to Mage default cooldowns
+
 ## v2.6.0
 
 ### Features

--- a/Core.lua
+++ b/Core.lua
@@ -8,7 +8,7 @@ local CB = Castborn
 
 -- Addon info
 CB.name = "Castborn"
-CB.version = "2.6.0"
+CB.version = "2.6.1"
 
 -- Module registry and event bus
 CB.modules = {}

--- a/Data/SpellData.lua
+++ b/Data/SpellData.lua
@@ -199,6 +199,7 @@ SpellData.dots = {
 SpellData.cooldowns = {
     MAGE = {
         { spellId = 45438, name = "Ice Block" },
+        { spellId = 11426, name = "Ice Barrier" },
         { spellId = 11958, name = "Cold Snap" },
         { spellId = 12472, name = "Icy Veins" },
         { spellId = 12042, name = "Arcane Power" },


### PR DESCRIPTION
Added Ice Barrier (11426) to Mage default cooldowns.