### PR TITLE
fix(pkgmeta): use CHANGELOG.md for CurseForge

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,5 +1,9 @@
 package-as: Castborn
 
+manual-changelog:
+  filename: CHANGELOG.md
+  markup-type: markdown
+
 ignore:
   - images
   - README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.6.2
+
+### Fixes
+- Fixed CurseForge changelog display
+
 ## v2.6.1
 
 ### Features

--- a/Core.lua
+++ b/Core.lua
@@ -8,7 +8,7 @@ local CB = Castborn
 
 -- Addon info
 CB.name = "Castborn"
-CB.version = "2.6.1"
+CB.version = "2.6.2"
 
 -- Module registry and event bus
 CB.modules = {}


### PR DESCRIPTION
CurseForge will now show the proper CHANGELOG.md instead of raw git commits.