### PR TITLE
fix(procs): icon draw layer above normal texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.6.4
+
+### Fixes
+- Fixed proc tracker icons showing as grey boxes (draw layer issue)
+
 ## v2.6.3
 
 ### Fixes

--- a/Core.lua
+++ b/Core.lua
@@ -8,7 +8,7 @@ local CB = Castborn
 
 -- Addon info
 CB.name = "Castborn"
-CB.version = "2.6.3"
+CB.version = "2.6.4"
 
 -- Module registry and event bus
 CB.modules = {}

--- a/Modules/ProcTracker.lua
+++ b/Modules/ProcTracker.lua
@@ -85,8 +85,8 @@ local function CreateProcFrame(parent, index)
     local f = CreateFrame("Button", "Castborn_Proc" .. index, parent)
     f:SetSize(size, size)
 
-    -- Icon texture
-    f.icon = f:CreateTexture(nil, "ARTWORK")
+    -- Icon texture (sublevel 1 to be above Normal texture)
+    f.icon = f:CreateTexture(nil, "ARTWORK", nil, 1)
     f.icon:SetAllPoints()
     f.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
     f.Icon = f.icon  -- Masque alias


### PR DESCRIPTION
SetNormalTexture() was putting the border in ARTWORK layer, covering the icon. Fixed by using sublevel 1 for the icon.