### PR TITLE
feat(interrupt): add resize controls and attach-to-castbars mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+**v6.7.0**
+
+- Added width and height sliders to Interrupt Tracker options
+- Added attach-to-castbars mode — interrupt cooldown icons appear on target/focus castbars
+- Added ready glow option for attached interrupt icons
+- Added Show Interrupt Bar toggle to hide the standalone bar when using attached mode
+- Fixed frame leak when toggling attach/detach mode repeatedly
+- Fixed attached icons not appearing when toggling attach mode during test mode
+
 **v6.6.0**
 
 - Added trinket proc tracking toggle — show or hide shared trinket procs separately from class procs

--- a/Core.lua
+++ b/Core.lua
@@ -291,6 +291,8 @@ CB.defaults = {
         xPct = 0,
         yPct = -0.199,
         bgColor = {0.05, 0.05, 0.05, 0.9},
+        attachToCastbars = false,
+        showReadyGlow = true,
     },
 
     procs = {

--- a/Core.lua
+++ b/Core.lua
@@ -8,7 +8,7 @@ local CB = Castborn
 
 -- Addon info
 CB.name = "Castborn"
-CB.version = "6.6.0"
+CB.version = "6.7.0"
 
 -- Module registry and event bus
 CB.modules = {}

--- a/Core.lua
+++ b/Core.lua
@@ -291,6 +291,7 @@ CB.defaults = {
         xPct = 0,
         yPct = -0.199,
         bgColor = {0.05, 0.05, 0.05, 0.9},
+        showBar = true,
         attachToCastbars = false,
         showReadyGlow = true,
     },

--- a/Modules/InterruptTracker.lua
+++ b/Modules/InterruptTracker.lua
@@ -170,10 +170,30 @@ function InterruptTracker:UpdateAttachMode()
                 attachedIcons[unit] = CreateAttachedIcon(unit)
             end
         end
+        -- If test mode is active, show attached icons immediately
+        if testModeActive then
+            for _, unit in ipairs({"target", "focus"}) do
+                local btn = attachedIcons[unit]
+                if btn then
+                    btn:Show()
+                    btn.icon:SetDesaturated(false)
+                    btn.cooldown:SetCooldown(0, 0)
+                    if db.showReadyGlow and btn.glow then
+                        btn.glow:SetAlpha(0.3)
+                    elseif btn.glow then
+                        btn.glow:SetAlpha(0)
+                    end
+                end
+            end
+        end
     else
         -- Hide attached icons (keep frames for reuse)
         for _, btn in pairs(attachedIcons) do
             btn:Hide()
+        end
+        -- If test mode is active, show standalone bar
+        if testModeActive and frame then
+            frame:Show()
         end
     end
 end

--- a/Modules/InterruptTracker.lua
+++ b/Modules/InterruptTracker.lua
@@ -391,7 +391,23 @@ function Castborn:TestInterrupt()
         end
     end
 
-    if frame then
+    if db.attachToCastbars then
+        -- In attach mode, hide standalone and show attached icons
+        if frame then frame:Hide() end
+        for _, unit in ipairs({"target", "focus"}) do
+            local btn = attachedIcons[unit]
+            if btn then
+                btn:Show()
+                btn.icon:SetDesaturated(false)
+                btn.cooldown:SetCooldown(0, 0)
+                if db.showReadyGlow and btn.glow then
+                    btn.glow:SetAlpha(0.3)
+                elseif btn.glow then
+                    btn.glow:SetAlpha(0)
+                end
+            end
+        end
+    elseif frame then
         frame:Show()
         if frame.bar then
             frame.bar:SetMinMaxValues(0, 1)
@@ -409,6 +425,10 @@ function Castborn:EndTestInterrupt()
     testModeActive = false
     if frame then
         frame:Hide()
+    end
+    for _, btn in pairs(attachedIcons) do
+        btn:Hide()
+        if btn.glow then btn.glow:SetAlpha(0) end
     end
 end
 

--- a/Modules/InterruptTracker.lua
+++ b/Modules/InterruptTracker.lua
@@ -161,9 +161,6 @@ end
 function InterruptTracker:UpdateAttachMode()
     local db = CastbornDB.interrupt
     if db.attachToCastbars then
-        -- Hide standalone
-        if frame then frame:Hide() end
-        if lockoutFrame then lockoutFrame:Hide() end
         -- Create attached icons if needed
         for _, unit in ipairs({"target", "focus"}) do
             if not attachedIcons[unit] then
@@ -190,10 +187,6 @@ function InterruptTracker:UpdateAttachMode()
         -- Hide attached icons (keep frames for reuse)
         for _, btn in pairs(attachedIcons) do
             btn:Hide()
-        end
-        -- If test mode is active, show standalone bar
-        if testModeActive and frame then
-            frame:Show()
         end
     end
 end
@@ -266,12 +259,6 @@ end
 local function UpdateInterruptCooldown()
     -- Don't override test mode display
     if testModeActive then return end
-
-    -- In attach mode, standalone bar is hidden
-    if CastbornDB.interrupt.attachToCastbars then
-        if frame then frame:Hide() end
-        return
-    end
 
     if not frame or not frame.interruptInfo then return end
 
@@ -409,9 +396,8 @@ function Castborn:TestInterrupt()
         end
     end
 
+    -- Show attached icons on castbars if enabled
     if db.attachToCastbars then
-        -- In attach mode, hide standalone and show attached icons
-        if frame then frame:Hide() end
         for _, unit in ipairs({"target", "focus"}) do
             local btn = attachedIcons[unit]
             if btn then
@@ -425,7 +411,10 @@ function Castborn:TestInterrupt()
                 end
             end
         end
-    elseif frame then
+    end
+
+    -- Always show standalone bar in test mode
+    if frame then
         frame:Show()
         if frame.bar then
             frame.bar:SetMinMaxValues(0, 1)

--- a/Modules/InterruptTracker.lua
+++ b/Modules/InterruptTracker.lua
@@ -19,6 +19,7 @@ local defaults = {
     showLockout = true,
     trackTarget = true,
     trackFocus = true,
+    showBar = true,
     attachToCastbars = false,
     showReadyGlow = true,
 }
@@ -263,7 +264,7 @@ local function UpdateInterruptCooldown()
     if not frame or not frame.interruptInfo then return end
 
     local db = CastbornDB.interrupt
-    if not db.enabled then
+    if not db.enabled or db.showBar == false then
         frame:Hide()
         return
     end

--- a/Modules/InterruptTracker.lua
+++ b/Modules/InterruptTracker.lua
@@ -5,6 +5,7 @@ Castborn.InterruptTracker = InterruptTracker
 local frame = nil
 local lockoutFrame = nil
 local testModeActive = false
+local attachedIcons = {}  -- { target = button, focus = button }
 
 local defaults = {
     enabled = true,
@@ -115,6 +116,107 @@ local function CreateLockoutDisplay()
     return lockoutFrame
 end
 
+local function CreateAttachedIcon(unit)
+    local castbar = Castborn.castbars and Castborn.castbars[unit]
+    if not castbar then return nil end
+
+    local db = CastbornDB.interrupt
+    local playerClass = select(2, UnitClass("player"))
+    local interruptInfo = Castborn.SpellData and Castborn.SpellData:GetInterrupt(playerClass)
+    if not interruptInfo then return nil end
+    if not Castborn:IsSpellKnown(interruptInfo.spellId) then return nil end
+
+    local castbarCfg = CastbornDB[unit]
+    local iconSize = (castbarCfg.height or 16) + 4
+
+    local masqueGroup = Castborn.Masque and Castborn.Masque.enabled and Castborn.Masque.groups.interrupts or nil
+    local btn = Castborn:CreateMasqueButton(castbar, nil, iconSize, masqueGroup, {
+        texCoord = 0.07,
+        clickThrough = true,
+    })
+    btn:SetPoint("LEFT", castbar, "RIGHT", 4, 0)
+    btn.icon:SetTexture(GetSpellTexture(interruptInfo.spellId))
+
+    -- Backdrop matching castbar style
+    Castborn:CreateBackdrop(btn, castbarCfg.bgColor, castbarCfg.borderColor)
+    btn.icon:ClearAllPoints()
+    btn.icon:SetPoint("TOPLEFT", 2, -2)
+    btn.icon:SetPoint("BOTTOMRIGHT", -2, 2)
+
+    -- Glow texture (same pattern as CooldownTracker)
+    btn.glowOuter = btn:CreateTexture(nil, "BACKGROUND", nil, -1)
+    btn.glowOuter:SetTexture("Interface\\SpellActivationOverlay\\IconAlert")
+    btn.glowOuter:SetTexCoord(0.00781250, 0.50781250, 0.27734375, 0.52734375)
+    btn.glowOuter:SetBlendMode("ADD")
+    btn.glowOuter:SetPoint("TOPLEFT", -8, 8)
+    btn.glowOuter:SetPoint("BOTTOMRIGHT", 8, -8)
+    btn.glowOuter:SetVertexColor(1, 0.8, 0.3, 0)
+    btn.glow = btn.glowOuter
+
+    btn.interruptInfo = interruptInfo
+    btn:Hide()
+
+    return btn
+end
+
+function InterruptTracker:UpdateAttachMode()
+    local db = CastbornDB.interrupt
+    if db.attachToCastbars then
+        -- Hide standalone
+        if frame then frame:Hide() end
+        if lockoutFrame then lockoutFrame:Hide() end
+        -- Create attached icons if needed
+        for _, unit in ipairs({"target", "focus"}) do
+            if not attachedIcons[unit] then
+                attachedIcons[unit] = CreateAttachedIcon(unit)
+            end
+        end
+    else
+        -- Hide and destroy attached icons
+        for unit, btn in pairs(attachedIcons) do
+            btn:Hide()
+            attachedIcons[unit] = nil
+        end
+    end
+end
+
+local function UpdateAttachedIcons()
+    local db = CastbornDB.interrupt
+    if not db.attachToCastbars then return end
+    if testModeActive then return end
+
+    for _, unit in ipairs({"target", "focus"}) do
+        local btn = attachedIcons[unit]
+        if btn then
+            local tracked = (unit == "target" and db.trackTarget ~= false) or
+                            (unit == "focus" and db.trackFocus ~= false)
+            local castbar = Castborn.castbars and Castborn.castbars[unit]
+            local castbarVisible = castbar and castbar:IsShown() and (castbar.casting or castbar.channeling)
+
+            if tracked and castbarVisible then
+                btn:Show()
+                local start, duration = GetSpellCooldown(btn.interruptInfo.spellId)
+                local onCooldown = duration and duration > 1.5
+                if onCooldown then
+                    btn.cooldown:SetCooldown(start, duration)
+                    btn.icon:SetDesaturated(true)
+                    if btn.glow then btn.glow:SetAlpha(0) end
+                else
+                    btn.cooldown:SetCooldown(0, 0)
+                    btn.icon:SetDesaturated(false)
+                    if db.showReadyGlow and btn.glow then
+                        btn.glow:SetAlpha(0.3)
+                    elseif btn.glow then
+                        btn.glow:SetAlpha(0)
+                    end
+                end
+            else
+                btn:Hide()
+            end
+        end
+    end
+end
+
 local function OnCombatLogEvent(self, event, ...)
     local timestamp, subEvent, hideCaster, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellId, spellName, spellSchool, extraSpellId, extraSpellName, extraSchool = CombatLogGetCurrentEventInfo()
     if sourceGUID ~= UnitGUID("player") then return end
@@ -146,6 +248,12 @@ end
 local function UpdateInterruptCooldown()
     -- Don't override test mode display
     if testModeActive then return end
+
+    -- In attach mode, standalone bar is hidden
+    if CastbornDB.interrupt.attachToCastbars then
+        if frame then frame:Hide() end
+        return
+    end
 
     if not frame or not frame.interruptInfo then return end
 
@@ -218,6 +326,7 @@ end)
 Castborn:RegisterCallback("READY", function()
     CreateInterruptBar()
     CreateLockoutDisplay()
+    InterruptTracker:UpdateAttachMode()
 
     local eventFrame = CreateFrame("Frame")
     eventFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
@@ -229,6 +338,7 @@ Castborn:RegisterCallback("READY", function()
         elapsed = elapsed + delta
         if elapsed >= 0.05 then
             UpdateInterruptCooldown()
+            UpdateAttachedIcons()
             UpdateLockout()
             elapsed = 0
         end

--- a/Modules/InterruptTracker.lua
+++ b/Modules/InterruptTracker.lua
@@ -18,6 +18,8 @@ local defaults = {
     showLockout = true,
     trackTarget = true,
     trackFocus = true,
+    attachToCastbars = false,
+    showReadyGlow = true,
 }
 
 local function CreateInterruptBar()

--- a/Modules/InterruptTracker.lua
+++ b/Modules/InterruptTracker.lua
@@ -120,7 +120,6 @@ local function CreateAttachedIcon(unit)
     local castbar = Castborn.castbars and Castborn.castbars[unit]
     if not castbar then return nil end
 
-    local db = CastbornDB.interrupt
     local playerClass = select(2, UnitClass("player"))
     local interruptInfo = Castborn.SpellData and Castborn.SpellData:GetInterrupt(playerClass)
     if not interruptInfo then return nil end
@@ -172,10 +171,9 @@ function InterruptTracker:UpdateAttachMode()
             end
         end
     else
-        -- Hide and destroy attached icons
-        for unit, btn in pairs(attachedIcons) do
+        -- Hide attached icons (keep frames for reuse)
+        for _, btn in pairs(attachedIcons) do
             btn:Hide()
-            attachedIcons[unit] = nil
         end
     end
 end

--- a/Systems/Options.lua
+++ b/Systems/Options.lua
@@ -2051,6 +2051,8 @@ function Options:BuildModule(parent, key)
         focusCB:SetPoint("TOPLEFT", 150, y)
         y = y - 30
 
+        local glowCB = CreateCheckbox(parent, "Show Ready Glow", db, "showReadyGlow")
+
         local attachCB = CreateCheckbox(parent, "Attach to Castbars", db, "attachToCastbars", function(checked)
             local f = _G["Castborn_Interrupt"]
             if f then
@@ -2061,11 +2063,11 @@ function Options:BuildModule(parent, key)
             if Castborn.InterruptTracker and Castborn.InterruptTracker.UpdateAttachMode then
                 Castborn.InterruptTracker:UpdateAttachMode()
             end
+            if checked then glowCB:Show() else glowCB:Hide() end
         end)
         attachCB:SetPoint("TOPLEFT", 0, y)
         y = y - 30
 
-        local glowCB = CreateCheckbox(parent, "Show Ready Glow", db, "showReadyGlow")
         glowCB:SetPoint("TOPLEFT", 0, y)
         if not db.attachToCastbars then glowCB:Hide() end
 

--- a/Systems/Options.lua
+++ b/Systems/Options.lua
@@ -2049,6 +2049,25 @@ function Options:BuildModule(parent, key)
         targetCB:SetPoint("TOPLEFT", 0, y)
         local focusCB = CreateCheckbox(parent, "Track Focus", db, "trackFocus")
         focusCB:SetPoint("TOPLEFT", 150, y)
+        y = y - 30
+
+        local attachCB = CreateCheckbox(parent, "Attach to Castbars", db, "attachToCastbars", function(checked)
+            local f = _G["Castborn_Interrupt"]
+            if f then
+                if checked then f:Hide() else f:Show() end
+            end
+            local lf = _G["Castborn_Lockout"]
+            if lf and checked then lf:Hide() end
+            if Castborn.InterruptTracker and Castborn.InterruptTracker.UpdateAttachMode then
+                Castborn.InterruptTracker:UpdateAttachMode()
+            end
+        end)
+        attachCB:SetPoint("TOPLEFT", 0, y)
+        y = y - 30
+
+        local glowCB = CreateCheckbox(parent, "Show Ready Glow", db, "showReadyGlow")
+        glowCB:SetPoint("TOPLEFT", 0, y)
+        if not db.attachToCastbars then glowCB:Hide() end
 
     elseif key == "totems" then
         db.width = db.width or 200

--- a/Systems/Options.lua
+++ b/Systems/Options.lua
@@ -2054,12 +2054,6 @@ function Options:BuildModule(parent, key)
         local glowCB = CreateCheckbox(parent, "Show Ready Glow", db, "showReadyGlow")
 
         local attachCB = CreateCheckbox(parent, "Attach to Castbars", db, "attachToCastbars", function(checked)
-            local f = _G["Castborn_Interrupt"]
-            if f then
-                if checked then f:Hide() else f:Show() end
-            end
-            local lf = _G["Castborn_Lockout"]
-            if lf and checked then lf:Hide() end
             if Castborn.InterruptTracker and Castborn.InterruptTracker.UpdateAttachMode then
                 Castborn.InterruptTracker:UpdateAttachMode()
             end

--- a/Systems/Options.lua
+++ b/Systems/Options.lua
@@ -2015,6 +2015,36 @@ function Options:BuildModule(parent, key)
         y = y - (26 * #db.trackedItems) - 60
 
     elseif key == "interrupt" then
+        local widthSlider = CreateSlider(parent, "Width", db, "width", 60, 300, 5, function(v)
+            local f = _G["Castborn_Interrupt"]
+            if f then
+                f:SetWidth(v)
+                if f.bar then
+                    f.bar:SetPoint("TOPLEFT", f, "TOPLEFT", (db.height or 16) + 2, -1)
+                end
+            end
+        end)
+        widthSlider:SetPoint("TOPLEFT", 0, y)
+
+        local heightSlider = CreateSlider(parent, "Height", db, "height", 10, 40, 1, function(v)
+            local f = _G["Castborn_Interrupt"]
+            if f then
+                f:SetHeight(v)
+                if f.iconButton then
+                    f.iconButton:SetSize(v, v)
+                end
+                if f.bar then
+                    f.bar:SetPoint("TOPLEFT", f, "TOPLEFT", v + 2, -1)
+                end
+            end
+        end)
+        heightSlider:SetPoint("TOPLEFT", 220, y)
+        y = y - 60
+
+        local lockoutCB = CreateCheckbox(parent, "Show Lockout", db, "showLockout")
+        lockoutCB:SetPoint("TOPLEFT", 0, y)
+        y = y - 30
+
         local targetCB = CreateCheckbox(parent, "Track Target", db, "trackTarget")
         targetCB:SetPoint("TOPLEFT", 0, y)
         local focusCB = CreateCheckbox(parent, "Track Focus", db, "trackFocus")

--- a/Systems/Options.lua
+++ b/Systems/Options.lua
@@ -2053,6 +2053,17 @@ function Options:BuildModule(parent, key)
 
         local glowCB = CreateCheckbox(parent, "Show Ready Glow", db, "showReadyGlow")
 
+        local showBarCB = CreateCheckbox(parent, "Show Interrupt Bar", db, "showBar", function(checked)
+            local f = _G["Castborn_Interrupt"]
+            if f then
+                if checked then f:Show() else f:Hide() end
+            end
+            local lf = _G["Castborn_Lockout"]
+            if lf and not checked then lf:Hide() end
+        end)
+        showBarCB:SetPoint("TOPLEFT", 0, y)
+        y = y - 30
+
         local attachCB = CreateCheckbox(parent, "Attach to Castbars", db, "attachToCastbars", function(checked)
             if Castborn.InterruptTracker and Castborn.InterruptTracker.UpdateAttachMode then
                 Castborn.InterruptTracker:UpdateAttachMode()

--- a/Systems/WhatsNew.lua
+++ b/Systems/WhatsNew.lua
@@ -14,6 +14,19 @@ local whatsNewFrame = nil
 
 local changelog = {
     {
+        version = "6.7.0",
+        features = {
+            "Added width and height sliders to Interrupt Tracker options",
+            "Added attach-to-castbars mode — interrupt cooldown icons appear on target/focus castbars",
+            "Added ready glow option for attached interrupt icons",
+            "Added Show Interrupt Bar toggle to hide the standalone bar when using attached mode",
+        },
+        fixes = {
+            "Fixed frame leak when toggling attach/detach mode repeatedly",
+            "Fixed attached icons not appearing when toggling attach mode during test mode",
+        },
+    },
+    {
         version = "6.6.0",
         features = {
             "Added trinket proc tracking toggle — show or hide shared trinket procs separately from class procs",


### PR DESCRIPTION
## Summary

- Add width and height sliders to Interrupt Tracker options for resizing the bar
- Add "Attach to Castbars" mode that shows interrupt cooldown icons on target/focus castbars with optional ready glow
- Add "Show Interrupt Bar" toggle so the standalone bar can be hidden when using attached mode

Fixes #177

## Test Plan

- [ ] Open options, verify width/height sliders resize the interrupt bar in real time
- [ ] Enable "Attach to Castbars" — verify interrupt icons appear on target/focus castbars
- [ ] Enable "Show Ready Glow" — verify glow appears when interrupt is off cooldown
- [ ] Disable "Show Interrupt Bar" — verify standalone bar hides while attached icons remain
- [ ] Toggle attach mode during `/cb test` — verify icons appear/disappear correctly
- [ ] `/cb test` — verify no frame leaks on repeated attach/detach toggling