### PR TITLE
fix(class-defaults): preserve user prefs on class change

### DIFF
--- a/Systems/ClassDefaults.lua
+++ b/Systems/ClassDefaults.lua
@@ -150,21 +150,26 @@ function ClassDefaults:ApplyFirstRunDefaults()
 
     if CastbornDB.firstRunComplete and not classChanged then return end
 
-    local defaults = self:GetPlayerDefaults()
+    local isFirstRun = not CastbornDB.firstRunComplete
 
-    CastbornDB.fsr = CastbornDB.fsr or {}
-    CastbornDB.fsr.enabled = self:ShouldShowFSR()
+    -- Only apply enabled-state defaults on first run so that user preferences are
+    -- respected when switching between characters of different classes.
+    if isFirstRun then
+        CastbornDB.fsr = CastbornDB.fsr or {}
+        CastbornDB.fsr.enabled = self:ShouldShowFSR()
 
-    CastbornDB.swing = CastbornDB.swing or {}
-    CastbornDB.swing.enabled = self:ShouldShowSwingTimer()
+        CastbornDB.swing = CastbornDB.swing or {}
+        CastbornDB.swing.enabled = self:ShouldShowSwingTimer()
+    end
 
-    -- Reset class-specific tracked spells when class changes
+    -- Signal ProcTracker and CooldownTracker to reload class spells on next session.
+    -- Do NOT clear trackedSpells here: CooldownTracker's READY callback already
+    -- preserves custom spells when reloading for a class change, but only if
+    -- trackedSpells is still intact when that callback runs.
     CastbornDB.procs = CastbornDB.procs or {}
-    CastbornDB.procs.trackedSpells = nil  -- Clear to allow ProcTracker to reload
     CastbornDB.procs.loadedForClass = nil
 
     CastbornDB.cooldowns = CastbornDB.cooldowns or {}
-    CastbornDB.cooldowns.trackedSpells = nil  -- Clear to allow CooldownTracker to reload
     CastbornDB.cooldowns.loadedForClass = nil
 
     CastbornDB.firstRunComplete = true


### PR DESCRIPTION
## Summary

- `ApplyFirstRunDefaults` was overwriting `fsr.enabled`/`swing.enabled` on every class switch (not just first run), re-enabling those modules against the user's saved preference
- It was also clearing `cooldowns.trackedSpells = nil` before `CooldownTracker`'s READY callback ran, which prevented custom spell preservation on class change

## Changes

`Systems/ClassDefaults.lua` — `ApplyFirstRunDefaults`:

- Added `isFirstRun` guard so `fsr.enabled` and `swing.enabled` are only written once (on first install), not on every subsequent class change
- Removed `trackedSpells = nil` for both cooldowns and procs — setting `loadedForClass = nil` alone signals the modules to reload; `CooldownTracker`'s own READY callback already has custom-spell preservation logic that requires `trackedSpells` to be intact

## Test plan

- [ ] On a multi-character account with alts of different classes: disable FSR on a mana class character, switch to another class alt and back — FSR should remain disabled
- [ ] Add a custom spell ID in the Cooldowns options, switch to another class alt and back — the custom spell should still be present
- [ ] Single-character first-run: FSR and Swing Timer should still be enabled/disabled correctly for the character's class on first login

Closes #179