### PR TITLE
fix(whatsnew): guard nil features/fixes in changelog render

### DIFF
--- a/Systems/WhatsNew.lua
+++ b/Systems/WhatsNew.lua
@@ -1072,7 +1072,7 @@ local function PopulateChangelog(scrollChild)
         y = y - 20
 
         -- Features section
-        if #entry.features > 0 then
+        if entry.features and #entry.features > 0 then
             local featuresLabel = scrollChild:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
             featuresLabel:SetPoint("TOPLEFT", 8, y)
             featuresLabel:SetText("|cff88ddffFeatures:|r")
@@ -1100,7 +1100,7 @@ local function PopulateChangelog(scrollChild)
         end
 
         -- Fixes section
-        if #entry.fixes > 0 then
+        if entry.fixes and #entry.fixes > 0 then
             local fixesLabel = scrollChild:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
             fixesLabel:SetPoint("TOPLEFT", 8, y)
             fixesLabel:SetText("|cff88ff88Fixes:|r")


### PR DESCRIPTION
## Problem

Opening `/cb` threw `WhatsNew.lua:1075: attempt to get length of field 'features' (a nil value)` (reported 8x by a user), and the What's New popup never appeared.

## Root cause

`PopulateChangelog` indexed `#entry.features` (line 1075) and `#entry.fixes` (line 1103) without a nil check. The current top changelog entry (`v6.7.1`) has only a `fixes` key, so `#entry.features` evaluated `#nil` and errored.

Because `WhatsNew:Show()` crashed before the popup displayed, `MarkAsSeen()` (which persists `lastSeenVersion`, only called from `WhatsNew:Hide()` on dismissal) never ran — so `ShouldShow()` stayed true and every subsequent `/cb` open re-triggered the crash.

## Fix

Nil-guard both length checks so any entry may omit `features` or `fixes`.

## Testing

- `luacheck` clean.
- Verified in-game: `/cb` no longer errors, the What's New popup displays and dismisses correctly, and castbar colours apply as expected.

Closes #181