### PR TITLE
ci(tests): run busted test suite on push and PR

### DIFF
--- a/.busted
+++ b/.busted
@@ -4,5 +4,6 @@ return {
     },
     default = {
         verbose = true,
+        ROOT = {"tests"},
     },
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  busted:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Lua
+        uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+
+      - name: Install LuaRocks
+        uses: leafo/gh-actions-luarocks@v4
+
+      - name: Install busted
+        run: luarocks install busted
+
+      - name: Run tests
+        run: busted

--- a/tests/mocks/wow_api.lua
+++ b/tests/mocks/wow_api.lua
@@ -38,5 +38,27 @@ _G.UIParent = {
     GetHeight = function() return 1080 end,
 }
 
+-- Mock CreateFrame — returns a frame-like table; unknown methods fall back to no-ops
+local function newMockFrame()
+    local frame = {
+        events = {},
+        scripts = {},
+    }
+    frame.RegisterEvent = function(self, event) self.events[event] = true end
+    frame.UnregisterEvent = function(self, event) self.events[event] = nil end
+    frame.SetScript = function(self, handler, fn) self.scripts[handler] = fn end
+    frame.GetScript = function(self, handler) return self.scripts[handler] end
+    frame.GetWidth = function() return 100 end
+    frame.GetHeight = function() return 20 end
+    setmetatable(frame, { __index = function() return function() end end })
+    return frame
+end
+
+_G.CreateFrame = function(frameType, name, parent, template)
+    local frame = newMockFrame()
+    if name then _G[name] = frame end
+    return frame
+end
+
 -- Return module for requiring
 return {}


### PR DESCRIPTION
Fixes #185

Adds a Tests workflow mirroring the existing luacheck one (Lua 5.1 + LuaRocks), installing busted and running the three existing spec files in tests/ on every push and PR to main.

Until now the busted suite never ran anywhere — busted is not installed locally and CI only ran luacheck.