### PR TITLE
fix(config): don't abort ResetPositions when a default is missing

### DIFF
--- a/Systems/Config.lua
+++ b/Systems/Config.lua
@@ -11,8 +11,7 @@ function CB:ResetPositions()
 
     for _, key in ipairs(positionKeys) do
         local def = CB.defaults[key]
-        if not def then break end
-        if CB.db[key] then
+        if def and CB.db[key] then
             CB.db[key].point = def.point
             CB.db[key].xPct = def.xPct
             CB.db[key].yPct = def.yPct

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,0 +1,34 @@
+require("tests.mocks.wow_api")
+dofile("Core.lua")
+dofile("Systems/Config.lua")
+
+describe("Config", function()
+    local CB = Castborn
+
+    describe("ResetPositions", function()
+        before_each(function()
+            CB.db = {
+                player = { point = "TOPLEFT", xPct = 0.5, yPct = 0.5 },
+                gcd = { point = "TOPLEFT", xPct = 0.5, yPct = 0.5 },
+            }
+        end)
+
+        it("resets positions to defaults", function()
+            CB:ResetPositions()
+            assert.are.equal(CB.defaults.player.point, CB.db.player.point)
+            assert.are.equal(CB.defaults.player.xPct, CB.db.player.xPct)
+            assert.are.equal(CB.defaults.player.yPct, CB.db.player.yPct)
+        end)
+
+        it("still resets later keys when an earlier key has no defaults", function()
+            local savedFocusDefaults = CB.defaults.focus
+            CB.defaults.focus = nil
+            CB:ResetPositions()
+            CB.defaults.focus = savedFocusDefaults
+            -- gcd comes after focus in positionKeys; it must still be reset
+            assert.are.equal(CB.defaults.gcd.point, CB.db.gcd.point)
+            assert.are.equal(CB.defaults.gcd.xPct, CB.db.gcd.xPct)
+            assert.are.equal(CB.defaults.gcd.yPct, CB.db.gcd.yPct)
+        end)
+    end)
+end)

--- a/tests/mocks/wow_api.lua
+++ b/tests/mocks/wow_api.lua
@@ -32,6 +32,11 @@ _G.GetRealmName = function()
     return "TestRealm"
 end
 
+-- Mock chat frame
+_G.DEFAULT_CHAT_FRAME = {
+    AddMessage = function() end,
+}
+
 -- Mock UIParent (minimal frame mock)
 _G.UIParent = {
     GetWidth = function() return 1920 end,


### PR DESCRIPTION
Fixes #186

ResetPositions used `if not def then break end`, so a single key missing from CB.defaults silently skipped every later key in positionKeys — a half-completed reset. It now skips just the missing key and continues.

First commit adds the regression test only (CI should show it red); second commit applies the fix. Also adds a DEFAULT_CHAT_FRAME mock so CB:Print works under busted.