### PR TITLE
chore(pkgmeta): exclude jpg files and RELEASE.md from package

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -13,6 +13,8 @@ ignore:
   - .github
   - "*.svg"
   - "*.png"
+  - "*.jpg"
+  - RELEASE.md
   - docs
   - tests
   - .luacheckrc


### PR DESCRIPTION
Fixes #187

The .pkgmeta ignore list covered *.png and *.svg but not *.jpg, so the tracked root file spell_arcane_arcane04.jpg shipped in the CurseForge zip. RELEASE.md (internal release checklist) also shipped, unlike README.md and CHANGELOG.md which are already ignored.

Adds "*.jpg" and RELEASE.md to the ignore list. Takes effect on the next tagged release via the BigWigs packager.