### PR TITLE
ci(workflows): bump actions/checkout to v5

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Lua
         uses: leafo/gh-actions-lua@v10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Package and Release
         uses: BigWigsMods/packager@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Lua
         uses: leafo/gh-actions-lua@v10


### PR DESCRIPTION
Fixes #192

Bumps actions/checkout from v4 to v5 in all three workflows (luacheck, tests, release). v4 targets the deprecated Node.js 20 runtime, which GitHub flagged during the v6.7.3 release run. The luacheck and tests jobs on this PR exercise the bumped action directly; the release workflow change gets exercised on the next tagged release.